### PR TITLE
Allow for changing directory to store solver tmp files

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,6 +30,7 @@ control_parameters:
         ]
     solver: "gurobi"
     solver_commandline_options: False
+    solver_tmp_dir: "default" # absolute or relative path; standard: "default"
     fuel_cost_pathway: "NZE"
     fuel_price_shock: "high"
     emissions_cost_pathway: "long-term"

--- a/pommesinvest/cli.py
+++ b/pommesinvest/cli.py
@@ -35,6 +35,7 @@ control_parameters:
     ]
     solver: "gurobi"
     solver_commandline_options: False
+    solver_tmp_dir: "default"
     fuel_cost_pathway: "NZE"
     fuel_price_shock: "high"
     emissions_cost_pathway: "long-term"

--- a/pommesinvest/model/investment_model.py
+++ b/pommesinvest/model/investment_model.py
@@ -56,9 +56,11 @@ import pandas as pd
 import yaml
 from oemof.solph import processing
 from oemof.solph import views
+from pyomo.common.tempfiles import TempfileManager
 from yaml.loader import SafeLoader
 
 from pommesinvest.model_funcs import model_control
+from pommesinvest.model_funcs.helpers import make_directory_if_missing
 from pommesinvest.model_funcs.results_processing import (
     process_demand_response_results,
     filter_storage_results,
@@ -122,6 +124,16 @@ def run_investment_model(config_file="./config.yml"):
                 f"{im.path_folder_output}pommesinvest_model.lp",
                 io_options={"symbolic_solver_labels": True},
             )
+        if im.solver_tmp_dir != "default":
+            logging.info(
+                f"Adjusting directory to store tmp solver files. "
+                f"Temporary files are stored at {im.solver_tmp_dir}"
+            )
+            if -1 < im.solver_tmp_dir.find("./") <= 1:
+                make_directory_if_missing(im.solver_tmp_dir, relative=True)
+            else:
+                make_directory_if_missing(im.solver_tmp_dir)
+            TempfileManager.tempdir = im.solver_tmp_dir
         if im.solver_commandline_options:
             logging.info(
                 "Using solver command line options.\n"

--- a/pommesinvest/model_funcs/helpers.py
+++ b/pommesinvest/model_funcs/helpers.py
@@ -12,6 +12,7 @@ Python version >= 3.8
 """
 
 import math
+import os
 from datetime import datetime
 from itertools import compress
 
@@ -221,11 +222,12 @@ def cut_leap_days(time_series):
         if is_leap_year(year):
             try:
                 time_series.drop(
-                        time_series.loc[
-                            (time_series.index.year == year)
-                            & (time_series.index.month == 12)
-                            & (time_series.index.day == 31)
-                        ].index, inplace=True
+                    time_series.loc[
+                        (time_series.index.year == year)
+                        & (time_series.index.month == 12)
+                        & (time_series.index.day == 31)
+                    ].index,
+                    inplace=True,
                 )
             except KeyError:
                 continue
@@ -316,3 +318,40 @@ def days_between(d1, d2):
     day_diff = abs((d2 - d1).days)
 
     return day_diff
+
+
+def make_directory_if_missing(folder: str, relative=False) -> None:
+    """Add directories if missing; works with at maximum 2 sub levels
+
+    Parameters
+    ----------
+    folder: str
+        path to folder to be created
+
+    relative: bool
+        If True, create new folder using a relative path;
+        else use absolute path
+    """
+    if os.path.exists(folder):
+        pass
+    else:
+        if os.path.exists(folder.rsplit("/", 2)[0]):
+            if not relative:
+                path = folder
+            else:
+                path = "./" + folder
+            os.mkdir(path)
+        else:
+            if not relative:
+                path = folder.rsplit("/", 2)[0]
+            else:
+                path = "./" + folder.rsplit("/", 2)[0]
+            os.mkdir(path)
+            subpath = folder
+            os.mkdir(subpath)
+    if not os.path.exists(folder):
+        raise ValueError(
+            f"Was not able to create path {folder}. "
+            f"Note that at most two non-existent sub levels "
+            f"for a path may be added."
+        )

--- a/pommesinvest/model_funcs/model_control.py
+++ b/pommesinvest/model_funcs/model_control.py
@@ -96,6 +96,10 @@ class InvestmentModel(object):
     solver_commandline_options: bool
         If True, use solver command line option; If False, use solver defaults
 
+    solver_tmp_dir: str
+        Directory for solver to store tmp files;
+        Will be adjusted if set other than 'default'
+    
     fuel_cost_pathway :  str
         A predefined pathway for commodity cost development until 2050
 
@@ -288,6 +292,7 @@ class InvestmentModel(object):
         self.countries = None
         self.solver = None
         self.solver_commandline_options = None
+        self.solver_tmp_dir = None
         self.fuel_cost_pathway = None
         self.fuel_price_shock = None
         self.emissions_cost_pathway = None


### PR DESCRIPTION
Introduce a new control option to specify the directory where solver tmp files (temporary lp files) are stored as a means of complexity management