### PR TITLE
Fix minimum load conflict with emissions limit

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -35,7 +35,7 @@ control_parameters:
     emissions_cost_pathway: "long-term"
     flexibility_options_scenario: "50"
     activate_emissions_budget_limit: False
-    activate_emissions_pathway_limit: False
+    activate_emissions_pathway_limit: True
     emissions_pathway: "KNS_2035"
     activate_demand_response: True
     demand_response_approach: "DLR"

--- a/pommesinvest/model/investment_model.py
+++ b/pommesinvest/model/investment_model.py
@@ -122,7 +122,6 @@ def run_investment_model(config_file="./config.yml"):
                 f"{im.path_folder_output}pommesinvest_model.lp",
                 io_options={"symbolic_solver_labels": True},
             )
-        from pyomo.util.infeasible import log_infeasible_constraints
         if im.solver_commandline_options:
             logging.info(
                 "Using solver command line options.\n"
@@ -137,7 +136,6 @@ def run_investment_model(config_file="./config.yml"):
             )
         else:
             im.om.solve(solver=im.solver, solve_kwargs={"tee": True})
-        log_infeasible_constraints(im.om)
         meta_results = processing.meta_results(im.om)
 
         model_meta["overall_objective"] = meta_results["objective"]

--- a/pommesinvest/model/investment_model.py
+++ b/pommesinvest/model/investment_model.py
@@ -122,6 +122,7 @@ def run_investment_model(config_file="./config.yml"):
                 f"{im.path_folder_output}pommesinvest_model.lp",
                 io_options={"symbolic_solver_labels": True},
             )
+        from pyomo.util.infeasible import log_infeasible_constraints
         if im.solver_commandline_options:
             logging.info(
                 "Using solver command line options.\n"
@@ -136,6 +137,7 @@ def run_investment_model(config_file="./config.yml"):
             )
         else:
             im.om.solve(solver=im.solver, solve_kwargs={"tee": True})
+        log_infeasible_constraints(im.om)
         meta_results = processing.meta_results(im.om)
 
         model_meta["overall_objective"] = meta_results["objective"]

--- a/pommesinvest/model_funcs/helpers.py
+++ b/pommesinvest/model_funcs/helpers.py
@@ -317,13 +317,3 @@ def days_between(d1, d2):
     day_diff = abs((d2 - d1).days)
 
     return day_diff
-
-
-def calculate_emissions_per_plant(t, outflow_args_el, sources_commodity):
-    """Calculate emissions of a plant caused by it running at minimum load"""
-    return sum(
-        outflow_args_el["min"]
-        * outflow_args_el["nominal_value"]
-        / t["efficiency_el"]
-        * sources_commodity.at[f"DE_source_{t['fuel']}", "emission_factors"]
-    )

--- a/pommesinvest/model_funcs/helpers.py
+++ b/pommesinvest/model_funcs/helpers.py
@@ -221,11 +221,12 @@ def cut_leap_days(time_series):
         if is_leap_year(year):
             try:
                 time_series.drop(
-                        time_series.loc[
-                            (time_series.index.year == year)
-                            & (time_series.index.month == 12)
-                            & (time_series.index.day == 31)
-                        ].index, inplace=True
+                    time_series.loc[
+                        (time_series.index.year == year)
+                        & (time_series.index.month == 12)
+                        & (time_series.index.day == 31)
+                    ].index,
+                    inplace=True,
                 )
             except KeyError:
                 continue
@@ -316,3 +317,13 @@ def days_between(d1, d2):
     day_diff = abs((d2 - d1).days)
 
     return day_diff
+
+
+def calculate_emissions_per_plant(t, outflow_args_el, sources_commodity):
+    """Calculate emissions of a plant caused by it running at minimum load"""
+    return sum(
+        outflow_args_el["min"]
+        * outflow_args_el["nominal_value"]
+        / t["efficiency_el"]
+        * sources_commodity.at[f"DE_source_{t['fuel']}", "emission_factors"]
+    )

--- a/pommesinvest/model_funcs/model_control.py
+++ b/pommesinvest/model_funcs/model_control.py
@@ -572,6 +572,12 @@ class InvestmentModel(object):
         Be aware that this may lead to model infeasibility
         if commodity bus balances cannot be met.
 
+        Also note that since flows minima and maxima are multiplied with
+        the multiplier accounting for the model frequency, considering
+        the model time increment (equal to the multiplier) would lead
+        to double accounting for emissions. Thus, emission factors are
+        scaled down using the multiplier.
+
         Parameters
         ----------
         emissions_limit : float
@@ -609,6 +615,11 @@ class InvestmentModel(object):
 
         for (i, o) in self.om.flows:
             if any(x in o.label for x in emission_flow_labels):
+                # Correct emission factors by multiplier
+                # in order not to double account emissions
+                self.om.flows[(i, o)].emission_factor = (
+                    self.om.flows[(i, o)].emission_factor / self.multiplier
+                )
                 emission_flows[(i, o)] = self.om.flows[(i, o)]
 
         if self.activate_emissions_budget_limit:

--- a/pommesinvest/model_funcs/subroutines.py
+++ b/pommesinvest/model_funcs/subroutines.py
@@ -705,7 +705,6 @@ def create_exogenous_transformers(
         # HACK: Use annual capacity values and max timeseries
         # to depict commissioning of new / decommissioning existing units
 
-        # TODO: Define minimum investment requirement for CHP units (also heat pumps etc as providers)
         maximum = (
             (
                 input_data["transformers_exogenous_max_ts"].loc[
@@ -730,7 +729,6 @@ def create_exogenous_transformers(
         }
 
         # Assign minimum loads for German CHP and IPP plants
-        # TODO: Create aggregated minimum load profiles!
         if t["type"] == "chp":
             if t["fuel"] in ["natgas", "hardcoal", "lignite"]:
                 outflow_args_el["min"] = (
@@ -761,6 +759,21 @@ def create_exogenous_transformers(
                 .to_numpy()
             )
 
+        # HACK: Reduce minimum output in order not to exceed emissions caps
+        multiplier = 1
+        if im.activate_emissions_budget_limit:
+            multiplier *= (
+                input_data["emission_development_factors"]
+                .loc[im.start_year : im.end_year, im.emissions_pathway]
+                .mean()
+            )
+        if im.activate_emissions_pathway_limit:
+            multiplier *= (
+                input_data["emission_development_factors"].loc[
+                    im.start_time : im.end_time, im.emissions_pathway
+                ]
+            ).values
+
         # Correct minimum load by maximum capacities of particular time
         outflow_args_el["min"] *= (
             input_data["transformers_exogenous_max_ts"]
@@ -769,6 +782,7 @@ def create_exogenous_transformers(
                 i,
             ]
             .to_numpy()
+            * multiplier
         )
 
         node_dict[i] = build_condensing_transformer(

--- a/pommesinvest/model_funcs/subroutines.py
+++ b/pommesinvest/model_funcs/subroutines.py
@@ -29,8 +29,6 @@ import oemof.solph as solph
 import pandas as pd
 from oemof.tools import economics
 
-from pommesinvest.model_funcs.helpers import calculate_emissions_per_plant
-
 
 def load_input_data(filename=None, im=None):
     r"""Load input data from csv files.
@@ -703,17 +701,6 @@ def create_exogenous_transformers(
         Modified dictionary containing all nodes of the EnergySystem including
         the exogenous transformer elements
     """
-    overall_emissions = {
-        "chp": {
-            fuel: 0 for fuel in input_data["exogenous_transformers"].fuel.unique()
-        },
-        "ipp": {
-            fuel: 0 for fuel in input_data["exogenous_transformers"].fuel.unique()
-        },
-        "other": {
-            fuel: 0 for fuel in input_data["exogenous_transformers"].fuel.unique()
-        },
-    }
     for i, t in input_data["exogenous_transformers"].iterrows():
         # HACK: Use annual capacity values and max timeseries
         # to depict commissioning of new / decommissioning existing units
@@ -774,24 +761,6 @@ def create_exogenous_transformers(
                 .to_numpy()
             )
 
-        # HACK: Reduce minimum output in order not to exceed emissions caps
-        # TODO: Find out why "real" emissions seem so far off limit and adjust
-        multiplier = 1
-        # if im.activate_emissions_budget_limit:
-        #     multiplier = 0.2
-        #     multiplier *= (
-        #         input_data["emission_development_factors"]
-        #         .loc[im.start_year : im.end_year, im.emissions_pathway]
-        #         .mean()
-        #     )
-        # if im.activate_emissions_pathway_limit:
-        #     multiplier = 0.3
-        #     multiplier *= (
-        #         input_data["emission_development_factors"].loc[
-        #             im.start_time : im.end_time, im.emissions_pathway
-        #         ]
-        #     ).values
-
         # Correct minimum load by maximum capacities of particular time
         outflow_args_el["min"] *= (
             input_data["transformers_exogenous_max_ts"]
@@ -800,25 +769,11 @@ def create_exogenous_transformers(
                 i,
             ]
             .to_numpy()
-            # HACK: Reduce minimum loads not to exceed emissions caps
-            * multiplier
         )
-
-        emissions_per_plant = calculate_emissions_per_plant(
-            t, outflow_args_el, input_data["sources_commodity"]
-        )
-        if t["type"] == "chp":
-            overall_emissions["chp"][t["fuel"]] += emissions_per_plant
-        elif t["type"] == "ipp":
-            overall_emissions["chp"][t["fuel"]] += emissions_per_plant
-        else:
-            overall_emissions["other"][t["fuel"]] += emissions_per_plant
 
         node_dict[i] = build_condensing_transformer(
             i, t, node_dict, outflow_args_el
         )
-
-    emissions_df = pd.DataFrame(overall_emissions)
 
     return node_dict
 


### PR DESCRIPTION
Comprises two things:
- Remove artificial scaling of minimum loads.
- Scale down emission factors in order not to "double account" for optimization frequency chosen.

Meanwhile, experimental changes have been introduced and undone again in order to evaluate the emissions caused by plants running at their minimum load output. It has been found that these are below allowed emission limits (as has been supposed).

This is introduced as a draft since testing for the longer term also considering the decline in allowed emissions which still might conflict with minimum load requirements still remains an open TODO.