### PR TITLE
Allow for discriminating WACC between technologies

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,6 +38,7 @@ control_parameters:
     activate_emissions_budget_limit: False
     activate_emissions_pathway_limit: True
     emissions_pathway: "KNS_2035"
+    use_technology_specific_wacc: True
     activate_demand_response: True
     demand_response_approach: "DLR"
     demand_response_scenario: "50"

--- a/pommesinvest/cli.py
+++ b/pommesinvest/cli.py
@@ -43,6 +43,7 @@ control_parameters:
     activate_emissions_budget_limit: False
     activate_emissions_pathway_limit: True
     emissions_pathway: "KNS_2035"
+    use_technology_specific_wacc: True
     activate_demand_response: False
     demand_response_approach: "DLR"
     demand_response_scenario: "50"

--- a/pommesinvest/model_funcs/model_control.py
+++ b/pommesinvest/model_funcs/model_control.py
@@ -214,6 +214,10 @@ class InvestmentModel(object):
         If an emissions budget limit is chosen, it is calculated based on the
         given pathway.
 
+    use_technology_specific_wacc: boolean
+        If True, discriminate wacc among technologies, else use interest_value
+        as wacc (social planner with ideal level-playing field)
+    
     activate_demand_response : boolean
         boolean control variable indicating whether to introduce
         demand response to the model
@@ -300,6 +304,7 @@ class InvestmentModel(object):
         self.activate_emissions_budget_limit = None
         self.activate_emissions_pathway_limit = None
         self.emissions_pathway = None
+        self.use_technology_specific_wacc = None
         self.activate_demand_response = None
         self.demand_response_approach = None
         self.demand_response_scenario = None


### PR DESCRIPTION
WACC may be discriminated among technologies. Hereby, input data fed in might also contain unique WACC values if the respective option is chosen in `pommesdata`.

Otherwise, WACC can be chosen to equal the interest rate (of usually 2%) which can be interpreted as an abstract ideal situation in which there is no discrimination between technologies in terms of their financing conditions.