### PR TITLE
Allow only for dedicated delay times in demand response approach DLR

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,6 +42,7 @@ control_parameters:
     activate_demand_response: True
     demand_response_approach: "DLR"
     demand_response_scenario: "50"
+    use_subset_of_delay_times: False
     impose_investment_maxima: True
     save_production_results: True
     save_investment_results: True
@@ -50,8 +51,8 @@ control_parameters:
 # 2) Set model optimization time and frequency
 time_parameters:
     start_time: "2020-01-01 00:00:00"
-    end_time: "2021-12-30 23:00:00"
-    freq: "24H"
+    end_time: "2020-12-30 23:00:00"
+    freq: "1H"
 
 # 3) Set input and output data paths
 input_output_parameters:

--- a/pommesinvest/cli.py
+++ b/pommesinvest/cli.py
@@ -47,6 +47,7 @@ control_parameters:
     activate_demand_response: False
     demand_response_approach: "DLR"
     demand_response_scenario: "50"
+    use_subset_of_delay_times: False
     impose_investment_maxima: True
     save_production_results: True
     save_investment_results: True

--- a/pommesinvest/model_funcs/model_control.py
+++ b/pommesinvest/model_funcs/model_control.py
@@ -233,6 +233,12 @@ class InvestmentModel(object):
         A predefined demand response scenario to be modeled
         Options: '5', '50', '95', whereby '5' is the lower,
         i.e. rather pessimistic estimate
+    
+    use_subset_of_delay_times : boolean
+        If True, only allow for a subset of the given maximum delay time
+        of demand response units. The allowed subset hereby is defined as
+        [1, 2, delay_time/2, delay_time] since this reflects short-, medium-
+        and long-term shifting processes while limiting model complexity.
 
     save_production_results : boolean
         boolean control variable indicating whether to save the dispatch
@@ -308,6 +314,7 @@ class InvestmentModel(object):
         self.activate_demand_response = None
         self.demand_response_approach = None
         self.demand_response_scenario = None
+        self.use_subset_of_delay_times = None
         self.save_production_results = None
         self.save_investment_results = None
         self.write_lp_file = None
@@ -521,6 +528,8 @@ class InvestmentModel(object):
                 f"for DEMAND RESPONSE modeling\n"
                 f"Considering a {self.demand_response_scenario}% scenario"
             )
+            if self.use_subset_of_delay_times:
+                dr_string += " using only a SUBSET of DELAY TIMES"
 
         else:
             dr_string = "Running a model WITHOUT DEMAND RESPONSE"


### PR DESCRIPTION
This introduces the option to only pass a subset of feasible delay times which comprises [1, 2, max_delay_time/2, max_delay_time].

This pull request is still a draft since a resulting error in postprocessing needs some attention and debugging.