### PR TITLE
Update dependencies to latest oemof.solph version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - pandas
   - pip:
       # TODO: Replace with release when available
-      - git+https://github.com/oemof/oemof-solph.git@features/multi-period
+      - git+https://github.com/oemof/oemof-solph.git@dev
       - pyyaml

--- a/environment_fixed_oemof_version.yml
+++ b/environment_fixed_oemof_version.yml
@@ -8,5 +8,5 @@ dependencies:
   - pandas
   - pip:
       # TODO: Replace with release when available
-      - git+https://github.com/oemof/oemof-solph.git@01ffed7ae6503cd4486ace96b8415ac2da4a9527
+      - git+https://github.com/oemof/oemof-solph.git@9627d126b81e6695f2e136742bc79c3f61aec84f
       - pyyaml

--- a/pommesinvest/model_funcs/helpers.py
+++ b/pommesinvest/model_funcs/helpers.py
@@ -172,14 +172,14 @@ def resample_timeseries(
         )
 
     try:
-        original_freq = pd.infer_freq(timeseries.index, warn=True)
+        original_freq = pd.infer_freq(timeseries.index)
     except ValueError:
         original_freq = "AS"
 
     # Hack for problems with recognizing abolishing the time shift
     if not original_freq:
         try:
-            original_freq = pd.infer_freq(timeseries.index[:5], warn=True)
+            original_freq = pd.infer_freq(timeseries.index[:5])
         except ValueError:
             raise ValueError("Cannot detect frequency of time series!")
 

--- a/pommesinvest/model_funcs/model_control.py
+++ b/pommesinvest/model_funcs/model_control.py
@@ -50,9 +50,9 @@ def adjust_datetime_index(periods):
 
     Parameters
     ----------
-    periods : dict
+    periods : list
         pd.date_ranges defining the time stamps for the respective period,
-        starting with period 0
+        starting with 0th period
 
     Returns
     -------
@@ -60,9 +60,9 @@ def adjust_datetime_index(periods):
         Actual datetime index of the model ignoring leap days
     """
     datetime_index = periods[0]
-    for period, timeindex in periods.items():
-        if period >= 1:
-            datetime_index = datetime_index.append(timeindex)
+    for number, period in enumerate(periods):
+        if number >= 1:
+            datetime_index = datetime_index.append(period)
 
     return datetime_index
 

--- a/pommesinvest/model_funcs/model_control.py
+++ b/pommesinvest/model_funcs/model_control.py
@@ -756,7 +756,7 @@ class InvestmentModel(object):
             starting with period 0
         """
         years = sorted(list(set(getattr(datetimeindex, "year"))))
-        periods = {}
+        periods = []
         filter_series = datetimeindex.to_series()
         for number, year in enumerate(years):
             start = filter_series.loc[filter_series.index.year == year].min()
@@ -769,7 +769,7 @@ class InvestmentModel(object):
                     & (filter_series.index.month == 12)
                     & (filter_series.index.day != 31)
                 ].max()
-            periods[number] = pd.date_range(start, end, freq=self.freq)
+            periods.append(pd.date_range(start, end, freq=self.freq))
 
         return periods
 

--- a/pommesinvest/model_funcs/subroutines.py
+++ b/pommesinvest/model_funcs/subroutines.py
@@ -240,7 +240,9 @@ def create_commodity_sources(input_data, im, node_dict):
                         .to_numpy()
                         * cs["emission_factors"]
                     ),
-                    emission_factor=cs["emission_factors"],
+                    custom_attributes={
+                        "emission_factor": cs["emission_factors"]
+                    },
                 )
             },
         )


### PR DESCRIPTION
Includes the following updates:
* `periods` attribute of energy system has been changed to type `list` instead of `dict`.
* `custom_attributes` have been introduced to allow for arbitrary keyword arguments, such as `emission_factor`.
* `pandas.infer_freq()` method has been updated.

Still pending: Introduction of fix for annual limit for load shedding.