### PR TITLE
Introduce variable costs for cross-border exchanges

### DIFF
--- a/pommesinvest/model_funcs/data_input.py
+++ b/pommesinvest/model_funcs/data_input.py
@@ -102,6 +102,9 @@ def parse_input_data(im):
             f"variable_costs_storages_"
             f"{im.flexibility_options_scenario}%_nominal"
         ),
+        "costs_operation_linking_transformers_ts": (
+            "costs_operation_linking_transformers_nominal_indexed_ts"
+        ),
         "costs_investment": (
             f"investment_expenses_{im.flexibility_options_scenario}%_nominal"
         ),
@@ -284,6 +287,7 @@ def resample_input_data(input_data, im):
         "costs_emissions_ts",
         "costs_operation_ts",
         "costs_operation_storages_ts",
+        "costs_operation_linking_transformers_ts",
         "linking_transformers_annual_ts",
         "storages_el_exogenous_max_ts",
     ]

--- a/pommesinvest/model_funcs/subroutines.py
+++ b/pommesinvest/model_funcs/subroutines.py
@@ -169,6 +169,9 @@ def create_linking_transformers(input_data, im, node_dict):
                             max=input_data["linking_transformers_annual_ts"]
                             .loc[im.start_time : im.end_time, i]
                             .to_numpy(),
+                            variable_costs=input_data[
+                                "costs_operation_linking_transformers_ts"
+                            ].loc[im.start_time : im.end_time, "values"],
                         )
                     },
                     outputs={node_dict[l["to"]]: solph.Flow()},
@@ -188,6 +191,9 @@ def create_linking_transformers(input_data, im, node_dict):
                             max=input_data["linking_transformers_ts"]
                             .loc[im.start_time : im.end_time, i]
                             .to_numpy(),
+                            variable_costs=input_data[
+                                "costs_operation_linking_transformers_ts"
+                            ].loc[im.start_time : im.end_time, "values"],
                         )
                     },
                     outputs={node_dict[l["to"]]: solph.Flow()},


### PR DESCRIPTION
Add variable costs for linking transformers in order to prevent excessive cross-border exchange.