### PR TITLE
Remove duplicate link results when considering European exchange

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -44,12 +44,12 @@ control_parameters:
     demand_response_scenario: "50"
     use_subset_of_delay_times: False
     impose_investment_maxima: True
-    include_artificial_shortage_units: True
+    include_artificial_shortage_units: False
     save_production_results: True
     save_investment_results: True
     write_lp_file: False
     extract_duals: True
-    extract_other_countries_production: False
+    extract_other_countries_production: True
     results_rounding_precision: 2
     sensitivity_parameter: "None"  # "None", "pv", "prices", "consumption"
     sensitivity_value: "None"  # "None", "-50%", "-25%", "+25%", "+50%"

--- a/pommesinvest/model/investment_model.py
+++ b/pommesinvest/model/investment_model.py
@@ -64,6 +64,7 @@ from pommesinvest.model_funcs.helpers import make_directory_if_missing
 from pommesinvest.model_funcs.results_processing import (
     process_demand_response_results,
     filter_storage_results,
+    filter_european_country_results,
 )
 
 
@@ -207,11 +208,10 @@ def run_investment_model(config_file="./config.yml"):
 
         dispatch_results = views.node(model_results, "DE_bus_el")["sequences"]
         if im.extract_other_countries_production:
-            buses_el_views = [country + "_bus_el" for country in im.countries]
             dispatch_results = pd.concat(
                 [
-                    views.node(model_results, bus_el)["sequences"]
-                    for bus_el in buses_el_views
+                    dispatch_results,
+                    filter_european_country_results(im, model_results),
                 ],
                 axis=1,
             )


### PR DESCRIPTION
Remove duplication of link results. They occur for both, the European electricity bus as well as another European country's electricity bus, but are required only once in order to have a functional filtering.