### PR TITLE
Add hint on reservoir storage limit

### DIFF
--- a/docs/model/formulation.rst
+++ b/docs/model/formulation.rst
@@ -363,7 +363,8 @@ with :math:`E_{nom}(s)` as the nominal storage capacity,
         & \forall \space s \in \mathrm{S}, \space t \in \mathrm{T}
 
 with :math:`E_{min}(s, t)` as the minimum and :math:`E_{max}(s, t)`
-as the maximum allowed storage content for time step t.
+as the maximum allowed storage content for time step t. For reservoir storages,
+these are derived from the historically observed filling rates.
 
 Constraints for core model extensions
 +++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
There is no additional inflow constraint introduced (as supposed), but the storage level limits are derived from historical inflows. Thus, there is no need for adding more constraints in the docs.